### PR TITLE
卡尔曼滤波模块预测部分添加控制矩阵 B 与控制向量 u

### DIFF
--- a/.github/workflows/build-by-cmake.yml
+++ b/.github/workflows/build-by-cmake.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   ubuntu2004-x86_64:
     uses: RoboMaster-Vision/ci-workflow/.github/workflows/rmvl-u20.yml@main
+  ubuntu2204-x86_64:
+    uses: RoboMaster-Vision/ci-workflow/.github/workflows/rmvl-u22.yml@main

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 **RoboMaster 视觉库**
 
-![image](https://img.shields.io/badge/OpenCV-4.5.0+-red) ![image](https://img.shields.io/badge/CMake-3.19+-blue)
+|      构建配置       |                             状态                             |
+| :-----------------: | :----------------------------------------------------------: |
+| Ubuntu 20.04 x86_64 | [![CMake in Linux](https://github.com/RoboMaster-Vision/RMVL/actions/workflows/build-by-cmake.yml/badge.svg)](https://github.com/RoboMaster-Vision/RMVL/actions/workflows/build-by-cmake.yml) |
 
 RMVL 是面向 RoboMaster 赛事的视觉库，旨在打造适用范围最广、使用最简洁、架构最统一、功能最强大的视觉库，并且以此建立和谐的纯技术向的 RoboMaster 视觉开源社区。
 

--- a/doc/tutorials/introduction/linux/tutorial_use.markdown
+++ b/doc/tutorials/introduction/linux/tutorial_use.markdown
@@ -29,44 +29,42 @@ touch main.cpp CMakeLists.txt
 ##### 2.1 编写 main.cpp
 
 将以下内容写至 `main.cpp` 中
+
 ```cpp
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
 
 #include <rmvl/detector.hpp>
 
-using namespace std;
-using namespace cv;
-
 int main(int argc, char *argv[])
 {
-    Mat src = Mat::zeros(Size(1280, 1024), CV_8UC3);
+    cv::Mat src = cv::Mat::zeros(cv::Size(1280, 1024), CV_8UC3);
 
-    line(src, Point(450, 380), Point(440, 470), Scalar(0, 0, 255), 18);
-    line(src, Point(650, 400), Point(640, 490), Scalar(0, 0, 255), 18);
-    line(src, Point(850, 370), Point(870, 460), Scalar(0, 0, 255), 18);
+    cv::line(src, cv::Point(450, 380), cv::Point(440, 470), cv::Scalar(0, 0, 255), 18);
+    cv::line(src, cv::Point(650, 400), cv::Point(640, 490), cv::Scalar(0, 0, 255), 18);
+    cv::line(src, cv::Point(850, 370), cv::Point(870, 460), cv::Scalar(0, 0, 255), 18);
 
-    detect_ptr detector = ArmorDetector::make_detector();
-    vector<group_ptr> groups;
+    rm::detect_ptr detector = rm::ArmorDetector::make_detector();
+    std::vector<rm::group_ptr> groups;
 
-    detector->detect(groups, src, RED, GyroData(), getTickCount());
+    detector->detect(groups, src, rm::RED, rm::GyroData{}, cv::getTickCount());
     auto p_combos = detector.combos;
 
     INFO_("size of armors = %ld", p_combos.size());
     for (auto &p_combo : p_combos)
     {
         auto corners = p_combo->getCorners();
-        line(src, corners[0], corners[2], Scalar(0, 255, 0), 2);
-        line(src, corners[1], corners[3], Scalar(0, 255, 0), 2);
+        cv::line(src, corners[0], corners[2], cv::Scalar(0, 255, 0), 2);
+        cv::line(src, corners[1], corners[3], cv::Scalar(0, 255, 0), 2);
     }
 
-    namedWindow("rmvl_deploy_test: src", WINDOW_NORMAL);
-    resizeWindow("rmvl_deploy_test: src", Size(640, 512));
-    imshow("rmvl_deploy_test: src", src);
+    cv::namedWindow("rmvl_deploy_test: src", cv::WINDOW_NORMAL);
+    cv::resizeWindow("rmvl_deploy_test: src", cv::Size(640, 512));
+    cv::imshow("rmvl_deploy_test: src", src);
 
     HIGHLIGHT_("RMVL build Successfully!\n\n\t\t-------- "
                "press any key to exit this program. --------\n");
-    waitKey(0);
+    cv::waitKey(0);
 
     return 0;
 }
@@ -76,17 +74,17 @@ int main(int argc, char *argv[])
 
 将以下内容写至 `CMakeLists.txt` 中
 ```cmake
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
+
 project(rmvl_deploy)
+
 find_package(RMVL REQUIRED)
+
 add_executable(demo main.cpp)
-target_include_directories(
-    demo
-    PUBLIC ${RMVL_INCLUDE_DIRS}
-)
+
 target_link_libraries(
     demo
-    ${RMVL_LIBS}
+    PRIVATE ${RMVL_LIBS}
 )
 ```
 

--- a/doc/tutorials/introduction/other/tutorial_other_arm.markdown
+++ b/doc/tutorials/introduction/other/tutorial_other_arm.markdown
@@ -12,7 +12,7 @@
 
 * Linux 主机
 
-* ![img](https://img.shields.io/badge/CMake-3.19+-green)
+* ![img](https://img.shields.io/badge/CMake-3.16+-green)
 
 * ![img](https://img.shields.io/badge/OpenCV_for_ARM-4.2.0+-red) [点击此处下载最新发行版](https://github.com/opencv/opencv/releases/latest)
 

--- a/doc/tutorials/introduction/tutorial_install_overview.markdown
+++ b/doc/tutorials/introduction/tutorial_install_overview.markdown
@@ -11,15 +11,15 @@
 
 - RMVL 唯一的一种安装方式：从源代码开始编译
 
-- 前往 https://git.scutbot.cn/Vision/RMVL/releases 并下载 "源代码" 存档
+- 前往 https://github.com/RoboMaster-Vision/RMVL/releases 并下载 "Release" 存档
 
 - 也可直接 clone RMVL 的远程存储库，这样您就可以体验 RMVL 的最新功能（可能不稳定）。
   ```shell
-  git clone https://git.scutbot.cn/Vision/RMVL.git
+  git clone https://github.com/RoboMaster-Vision/RMVL.git
   ```
 
 #### CMake 架构
 
-- RMVL 采用 [CMake](https://cmake.org) 构建管理系统进行配置和构建。在 3.6.0 开始，版本号最低要求为 3.16。
+- RMVL 采用 [CMake](https://cmake.org) 构建管理系统进行配置和构建。版本号最低要求为 3.16。
 
 - RMVL 设置丰富的编译选项，可供您在 CMake 配置期间根据您的环境配置，或者预期功能选择您想构建的部分。

--- a/doc/tutorials/introduction/tutorial_table_of_content_introduction.markdown
+++ b/doc/tutorials/introduction/tutorial_table_of_content_introduction.markdown
@@ -20,4 +20,4 @@
 
 #### 杂项
 
-- @subpage tutorial_document - 本教程描述了一些新颖的文档过程，以及介绍了实用的 Doxygen 特性
+- @subpage tutorial_document - 本教程描述了文档的生成过程，并且介绍了实用的 Doxygen 特性

--- a/doc/tutorials/modules/core/kalman.md
+++ b/doc/tutorials/modules/core/kalman.md
@@ -12,7 +12,7 @@
 
 ------
 
-相关类 rm::KalmanFilterX
+相关类 rm::KalmanFilter
 
 ## 1. 卡尔曼滤波理论
 
@@ -215,12 +215,12 @@ z_1,\ z_2,\ z_3\ \dots\ z_n
 
 ### 2.1 如何配置
 
-在 CMakeLists.txt 中链接库
+首先必须要寻找 RMVL 包，即 `find_package(RMVL [OPTIONS])`，之后可直接在中使用在 CMakeLists.txt 中链接库
 
 ```cmake
 target_link_libraries(
     xxx
-    rmvl_kalman
+    rmvl_core
 )
 ```
 
@@ -229,16 +229,16 @@ target_link_libraries(
 #### 2.2.1 包含头文件
 
 ```cpp
-#include <rmvl/filter/kalman.hpp>
+#include <rmvl/core/kalman.hpp>
 ```
 
 #### 2.2.2 创建并初始化卡尔曼滤波器对象
 
 ```cpp
-KalmanFilterX<n, n> filter;
+KalmanFilter<state, meature, control> filter;
 filter.setR(/* ... */);
 filter.setQ(/* ... */);
-cv::Vec<float, n> init_vec = {/* ... */};
+cv::Vec<float, state> init_vec = {/* ... */};
 filter.init(init_vec, pred_err);
 ```
 

--- a/modules/core/include/rmvl/core/kalman.hpp
+++ b/modules/core/include/rmvl/core/kalman.hpp
@@ -15,43 +15,57 @@
 #pragma once
 
 #include <opencv2/core/matx.hpp>
+#include <type_traits>
 
 //! @addtogroup core
 //! @{
 //!     @defgroup core_kalman 卡尔曼滤波器库
 //! @}
 
+namespace rm
+{
+
 //! @addtogroup core_kalman 卡尔曼滤波器库
 //! @{
 
 /**
- * @brief 使用 `cv::Matx` 的轻量级卡尔曼滤波器库
+ * @brief 轻量级 `cv::Matx` 的卡尔曼滤波模块
  *
+ * @note 相关知识点说明文档可参考 @ref tutorial_modules_kalman
  * @tparam Tp 数据类型
  * @tparam StateDim 状态向量的维度，类型是 `uint16_t`
- * @tparam MeasureDim The 观测向量的维度，类型是 `uint16_t`
+ * @tparam MeasureDim 观测向量的维度，类型是 `uint16_t`
+ * @tparam ControlDim 控制向量的维度，类型是 `uint16_t`，默认为 `1`
  */
-template <typename Tp, uint16_t StateDim, uint16_t MeasureDim>
-class KalmanFilterX
+template <typename Tp, uint16_t StateDim, uint16_t MeasureDim, uint16_t ControlDim = 1>
+class KalmanFilter
 {
-    cv::Matx<Tp, StateDim, StateDim> A;     //!< 状态转移矩阵 \f$A\f$
-    cv::Matx<Tp, StateDim, StateDim> At;    //!< 状态转移矩阵 `A` 的转置矩阵 \f$A^T\f$
+#if __cplusplus >= 201703L
+    static_assert(std::is_floating_point_v<Tp>, "\"Tp\" must be floating point value.");
+    static_assert(ControlDim != 0, "ControlDim of \"rm::KalmanFilter\" must greater than 0.");
+#endif // C++17
+
+    cv::Matx<Tp, StateDim, StateDim> A;   //!< 状态转移矩阵 \f$A\f$
+    cv::Matx<Tp, StateDim, StateDim> At;  //!< 状态转移矩阵 `A` 的转置矩阵 \f$A^T\f$
+    cv::Matx<Tp, StateDim, 1> x;          //!< 后验状态估计 \f$\hat x\f$
+    cv::Matx<Tp, StateDim, 1> x_;         //!< 先验状态估计 \f$\hat x^-\f$
+    cv::Matx<Tp, StateDim, ControlDim> B; //!< 控制量直接对状态量作用的矩阵：控制矩阵 `B` \f$B\f$
+    cv::Matx<Tp, ControlDim, 1> u;        //!< 控制向量 `u` \f$\vec{u}\f$
+
     cv::Matx<Tp, MeasureDim, StateDim> H;   //!< 观测转换矩阵 \f$H\f$
     cv::Matx<Tp, StateDim, MeasureDim> Ht;  //!< 观测转换矩阵 `H` 的转置矩阵 \f$H^T\f$
-    cv::Matx<Tp, StateDim, 1> xhat;         //!< 后验状态估计 \f$\hat x\f$
-    cv::Matx<Tp, StateDim, 1> xhat_;        //!< 先验状态估计 \f$\hat x^-\f$
     cv::Matx<Tp, StateDim, StateDim> Q;     //!< 过程噪声协方差矩阵 \f$Q\f$
     cv::Matx<Tp, MeasureDim, MeasureDim> R; //!< 测量噪声协方差矩阵 \f$R\f$
     cv::Matx<Tp, StateDim, StateDim> P;     //!< 后验状态误差协方差矩阵 \f$P\f$
     cv::Matx<Tp, StateDim, StateDim> P_;    //!< 先验状态误差协方差矩阵 \f$P^-\f$
-    cv::Matx<Tp, StateDim, StateDim> I;     //!< 单位矩阵 \f$I\f$
-    cv::Matx<Tp, StateDim, MeasureDim> K;   //!< 卡尔曼增益 \f$K\f$
-    cv::Matx<Tp, MeasureDim, 1> z;          //!< 观测向量 \f$z\f$
+    cv::Matx<Tp, StateDim, StateDim> I;     //!< 单位矩阵 `I` \f$I\f$
+    cv::Matx<Tp, StateDim, MeasureDim> K;   //!< 卡尔曼增益 `K` \f$K\f$
+    cv::Matx<Tp, MeasureDim, 1> z;          //!< 观测向量 `z` \f$\vec{z}\f$
 
 public:
-    //! 构造新的 KalmanFilterX 对象
-    KalmanFilterX() : A(A.eye()), At(At.eye()), H(H.eye()), Ht(Ht.eye()),
-                      Q(Q.eye()), R(R.eye()), P(P.eye()), I(I.eye()) {}
+    //! 构造新的 KalmanFilter 对象
+    KalmanFilter() : A(A.eye()), At(At.eye()), H(H.eye()), Ht(Ht.eye()),
+                     Q(Q.eye()), R(R.eye()), P(P.eye()), I(I.eye()) {}
 
     /**
      * @brief 初始化状态以及对应的误差协方差矩阵（常数对角矩阵）
@@ -61,7 +75,7 @@ public:
      */
     void init(const cv::Matx<Tp, StateDim, 1> &state, Tp error)
     {
-        xhat_ = xhat = state;
+        x_ = x = state;
         P_ = P = P.eye() * error;
     }
 
@@ -73,34 +87,52 @@ public:
      */
     void init(const cv::Matx<Tp, StateDim, 1> &state, const cv::Matx<Tp, StateDim, 1> &error)
     {
-        xhat_ = xhat = state;
+        x_ = x = state;
         P_ = P = P.diag(error);
     }
 
     /**
      * @brief 设置状态转移矩阵 `A`
-     * @note 包含 `x` 方向位置、`y` 方向位置、`x` 方向速度和 `y` 方向速度的运动过程一般可以描述为
-     *       \f[\left\{\begin{array}{rl}x_{n+1}&=&x_n+v_{x_n}t\\y_{n+1}&=&y_n+v_{y_n}t\\v_{x_{n+1}}&=&
-     *       v_{x_n}\\v_{y_{n+1}}&=&v_{y_n}\end{array}\right.\f] Using the matrix formula denoted as
-     *       \f[\begin{bmatrix}x_{n+1}\\y_{n+1}\\v_{x_{n+1}}\\v_{y_{n+1}}\end{bmatrix}=
-     *       \begin{bmatrix}1&0&t&0\\0&1&0&t\\0&0&1&0\\0&0&0&1\end{bmatrix}
-     *       \begin{bmatrix}x_n\\y_n\\v_{x_n}\\v_{y_n}\end{bmatrix}\f] Which is \f$X_{n+1}=AX_n\f$.
-     *       在这条公式中，矩阵 \f$A\f$ 被称为状态转移矩阵
+     * @details
+     * 包含 `x` 方向位置、`y` 方向位置、`x` 方向速度和 `y` 方向速度的运动过程一般可以描述为
+     * \f[\left\{\begin{align}x_{n+1}&=x_n+{v_x}_nt+\frac12{a_x}_nt^2\\y_{n+1}&=y_n+{v_y}_nt
+     * +\frac12{a_y}_nt^2\\{v_x}_{n+1}&={v_x}_n+{a_x}_nt\\{v_y}_{n+1}&={v_y}_n+{a_y}_nt
+     * \end{align}\right.\tag1\f]使用矩阵表示为\f[\begin{bmatrix}x_{n+1}\\y_{n+1}\\{v_x}_{n+1}\\
+     * {v_y}_{n+1}\end{bmatrix}=\begin{bmatrix}1&0&t&0\\0&1&0&t\\0&0&1&0\\0&0&0&1\end{bmatrix}
+     * \begin{bmatrix}x_n\\y_n\\{v_x}_n\\{v_y}_n\end{bmatrix}+\begin{bmatrix}\frac12t^2&0\\
+     * 0&\frac12t^2\\t&0\\0&t\end{bmatrix}\begin{bmatrix}{a_x}_n\\{a_y}_n\end{bmatrix}\tag2\f]
+     * 即可以写成\f[\pmb{x}_{n+1}=A\pmb{x}_n+B\pmb{u}_n\tag3\f]
+     * 在这条公式中
+     * - \f$A\f$ 是状态转移矩阵
+     * - \f$\pmb x\f$ 是状态向量
+     * - \f$n\f$ 和 \f$n+1\f$ 表示当前帧和上一帧的数据
+     * - \f$B\f$ 是控制矩阵
+     * - \f$\pmb u\f$ 是控制向量
      *
-     * @param[in] _A 状态转移矩阵
+     * @param[in] state_tf 状态转移矩阵
      */
-    inline void setA(const cv::Matx<Tp, StateDim, StateDim> &_A) { A = _A, At = _A.t(); }
+    inline void setA(const cv::Matx<Tp, StateDim, StateDim> &state_tf) { A = state_tf, At = state_tf.t(); }
+
+    /**
+     * @brief 设置控制矩阵 `B`
+     * @details 输入直接对状态向量的作用，由控制矩阵 `B` 定义
+     * @see setA
+     *
+     * @param[in] control_matrix 控制矩阵
+     */
+    inline void setB(const cv::Matx<Tp, StateDim, ControlDim> &control_matrix) { B = control_matrix; }
 
     /**
      * @brief 设置观测转换矩阵 `H`
-     * @note 若状态向量包含以下内容：\f$[p, v, a]\f$ ，然而观测向量仅包含 \f$[p, v]\f$，
-     *       在这种情况下，需要使用一个观测转换矩阵 \f$H_{2\times3}\f$。在上述例子中克表示为
-     *       \f[\begin{bmatrix}p\\v\end{bmatrix}=\begin{bmatrix}1&0&0\\0&1&0\end{bmatrix}
-     *       \begin{bmatrix}p\\v\\a\end{bmatrix}\f]
-     *
-     * @param[in] _H 观测转换矩阵
+     * @details
+     * 若状态向量包含以下内容：\f$[p, v, a]^T\f$ ，然而观测向量仅包含 \f$[p, v]^T\f$，
+     * 在这种情况下，需要使用一个观测转换矩阵 \f$H_{2\times3}\f$。在上述例子中克表示为
+     * \f[\begin{bmatrix}p\\v\end{bmatrix}=\begin{bmatrix}1&0&0\\0&1&0\end{bmatrix}
+     * \begin{bmatrix}p\\v\\a\end{bmatrix}\f]
+     * @note `H` 若不加以设置，则默认是单位矩阵 \f$I\f$
+     * @param[in] observe_tf 观测转换矩阵
      */
-    inline void setH(const cv::Matx<Tp, MeasureDim, StateDim> &_H) { H = _H, Ht = _H.t(); }
+    inline void setH(const cv::Matx<Tp, MeasureDim, StateDim> &observe_tf) { H = observe_tf, Ht = observe_tf.t(); }
 
     /**
      * @brief 设置测量噪声协方差矩阵 `R`
@@ -124,21 +156,44 @@ public:
     inline void setP(const cv::Matx<Tp, StateDim, StateDim> &state_err) { P_ = P = state_err; }
 
     /**
-     * @brief 卡尔曼滤波的预测部分，包括状态向量的先验估计和误差协方差的先验估计
+     * @brief 含控制量的卡尔曼滤波的预测部分，包括状态向量的先验估计和误差协方差的先验估计
+     * @details 预测部分公式如下
+     *          \f[\begin{align}\hat{\pmb x}^-&=A\hat{\pmb x}+B\pmb u\\P^-&=APA^T+Q\end{align}\f]
+     *
+     * @param[in] control_vec 控制向量
+     * @return 先验状态估计
+     */
+    inline auto predict(const cv::Matx<Tp, ControlDim, 1> &control_vec)
+    {
+        u = control_vec;
+        // 估计先验状态，考虑控制向量
+        x_ = A * x + B * u;
+        // 估计先验误差协方差
+        P_ = A * P * At + Q;
+        return x_;
+    }
+
+    /**
+     * @brief 不含控制量的卡尔曼滤波的预测部分，包括状态向量的先验估计和误差协方差的先验估计
+     * @see predict(const cv::Matx<Tp, ControlDim, 1> &control)
+     * @note 公式中 \f$B\pmb u = \pmb 0\f$
      *
      * @return 先验状态估计
      */
     inline auto predict()
     {
-        // Estimate the prior state vector
-        xhat_ = A * xhat;
-        // Estimate the prior error covariance
+        // 估计先验状态
+        x_ = A * x;
+        // 估计先验误差协方差
         P_ = A * P * At + Q;
-        return xhat_;
+        return x_;
     }
 
     /**
      * @brief 卡尔曼滤波器的校正部分，包括卡尔曼增益 `K` 的计算、状态向量的后验估计和误差协方差的校正
+     * @details
+     * 更新部分公式如下 \f[\begin{align}K&=P^-H^T\left(HP^-H^T+R\right)^{-1}\\\hat{\pmb x}&=
+     * \hat{\pmb x}^-+K\left(\pmb z-H\hat{\pmb x}^-\right)\\P&=\left(I-KH\right)P^-\end{align}\f]
      *
      * @param[in] measurement 观测向量
      * @return 后验状态估计
@@ -146,25 +201,27 @@ public:
     inline auto correct(const cv::Matx<Tp, MeasureDim, 1> &measurement)
     {
         z = measurement;
-        // Calculate the Kalman gain: K
+        // 计算卡尔曼增益 `K`
         K = P_ * Ht * (H * P_ * Ht + R).inv();
-        // Estimate the posterior state. In other words, update the state estimation
-        xhat = xhat_ + K * (z - H * xhat_);
-        // Correction the error covariance
+        // 估计后验状态，即完成状态的更新
+        x = x_ + K * (z - H * x_);
+        // 估计后验误差协方差，即校正、更新误差协方差
         P = (I - K * H) * P_;
-        return xhat;
+        return x;
     }
 };
 
-using KF11f = KalmanFilterX<float, 1U, 1U>;  //!< 1 × 1 卡尔曼滤波类
-using KF11d = KalmanFilterX<double, 1U, 1U>; //!< 1 × 1 卡尔曼滤波类
-using KF22f = KalmanFilterX<float, 2U, 2U>;  //!< 2 × 2 卡尔曼滤波类
-using KF22d = KalmanFilterX<double, 2U, 2U>; //!< 2 × 2 卡尔曼滤波类
-using KF33f = KalmanFilterX<float, 3U, 3U>;  //!< 3 × 3 卡尔曼滤波类
-using KF33d = KalmanFilterX<double, 3U, 3U>; //!< 3 × 3 卡尔曼滤波类
-using KF44f = KalmanFilterX<float, 4U, 4U>;  //!< 4 × 4 卡尔曼滤波类
-using KF44d = KalmanFilterX<double, 4U, 4U>; //!< 4 × 4 卡尔曼滤波类
-using KF66f = KalmanFilterX<float, 6U, 6U>;  //!< 6 × 6 卡尔曼滤波类
-using KF66d = KalmanFilterX<double, 6U, 6U>; //!< 6 × 6 卡尔曼滤波类
+using KF11f = KalmanFilter<float, 1U, 1U>;  //!< 1 × 1 卡尔曼滤波器，无控制量
+using KF11d = KalmanFilter<double, 1U, 1U>; //!< 1 × 1 卡尔曼滤波器，无控制量
+using KF22f = KalmanFilter<float, 2U, 2U>;  //!< 2 × 2 卡尔曼滤波器，无控制量
+using KF22d = KalmanFilter<double, 2U, 2U>; //!< 2 × 2 卡尔曼滤波器，无控制量
+using KF33f = KalmanFilter<float, 3U, 3U>;  //!< 3 × 3 卡尔曼滤波器，无控制量
+using KF33d = KalmanFilter<double, 3U, 3U>; //!< 3 × 3 卡尔曼滤波器，无控制量
+using KF44f = KalmanFilter<float, 4U, 4U>;  //!< 4 × 4 卡尔曼滤波器，无控制量
+using KF44d = KalmanFilter<double, 4U, 4U>; //!< 4 × 4 卡尔曼滤波器，无控制量
+using KF66f = KalmanFilter<float, 6U, 6U>;  //!< 6 × 6 卡尔曼滤波器，无控制量
+using KF66d = KalmanFilter<double, 6U, 6U>; //!< 6 × 6 卡尔曼滤波器，无控制量
 
 //! @} kalman
+
+} // namespace rm

--- a/modules/rmath/include/rmvl/rmath/ra_heap.hpp
+++ b/modules/rmath/include/rmvl/rmath/ra_heap.hpp
@@ -32,7 +32,7 @@ template <typename Tp, typename Sequence = std::vector<Tp>, typename Compare = s
 class RaHeap
 {
 #if __cplusplus >= 201703L
-    static_assert(std::is_same<Tp, typename Sequence::value_type>::value,
+    static_assert(std::is_same_v<Tp, typename Sequence::value_type>,
                   "value_type must be the same as the underlying container");
 #endif // C++17
 


### PR DESCRIPTION
### Pull Request 准备清单

详情参见[此处](https://github.com/RoboMaster-Vision/RMVL/wiki/How_to_contribute#3-%E6%8F%90%E4%BA%A4%E8%89%AF%E5%A5%BD%E7%9A%84-pr)

- [x] 我同意在 Apache 2 开源许可下为本项目做贡献
- [x] 此 pull request 是在正确的分支上提出的
- [x] 此 pull request 有对应的错误报告或其他待改进的内容
- [x] 我本地的 RMVL 进行了单元测试、性能测试，有对应的测试数据
- [x] 我提交的 feature 有很好的文档记录，并且可以使用 CMake 项目构建示例代码

### 具体内容

- 卡尔曼滤波公式改为 $\hat{x}^- = A\hat{x} + Bu$